### PR TITLE
Make Rate Limiting Toggleable

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ Additionally the `API_MAX_REQUESTS` environment variable can be used to override
 $ export API_MAX_REQUESTS=1000
 ```
 
+Setting `API_MAX_REQUESTS` to 0 or a negative number will result in rate limiting being turned off. Which may be helpful during development.
+
 #### Run:
 ```
 docker start chargen-mysql-server

--- a/src/utils/rate-limit-helper.ts
+++ b/src/utils/rate-limit-helper.ts
@@ -49,6 +49,10 @@ export async function initializeRateLimiting(): Promise<void> {
 }
 
 export async function rateLimit(req: Request, res: Response, next: NextFunction): Promise<void> {
+    if (rateLimitWindowMaxRequests <= 0) {
+        next();
+        return;
+    }
     try {
         const ip: string = String(req.ip);
 


### PR DESCRIPTION
This PR makes it so that rate limiting can be turned off by setting the `API_MAX_REQUESTS` environment variable to 0 or a negative number.